### PR TITLE
Update Kotlin definition

### DIFF
--- a/languages/kotlin/code/pom.xml
+++ b/languages/kotlin/code/pom.xml
@@ -11,10 +11,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <java.version>1.8</java.version>
+        <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <java.version>21</java.version>
     </properties>
 
     <repositories>
@@ -24,13 +24,26 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+      <dependencies>
+          <dependency>
+              <groupId>org.jetbrains.kotlin</groupId>
+              <artifactId>kotlin-bom</artifactId>
+              <version>2.0.0</version>
+              <type>pom</type>
+              <scope>import</scope>
+          </dependency>
+      </dependencies>
+    </dependencyManagement>
+
+
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>1.9.10</version>
+                <version>2.0.0</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -77,7 +90,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>1.9.10</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Use Kotlin 2.0 with Java 21 (latest LTS), docker file already says so.

Use kotlin BOM instead of setting dependencies manually