### PR TITLE
Add Swift 6 support

### DIFF
--- a/languages/swift/code/.codecrafters/compile.sh
+++ b/languages/swift/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+swift build -c release

--- a/languages/swift/code/.codecrafters/compile.sh
+++ b/languages/swift/code/.codecrafters/compile.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-swift build -c release
+swift build -c release --build-path /tmp/codecrafters-build-{{course_slug}}-swift

--- a/languages/swift/code/.codecrafters/run.sh
+++ b/languages/swift/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec swift run -c release --skip-build build-your-own-{{course_slug}} "$@"

--- a/languages/swift/code/.codecrafters/run.sh
+++ b/languages/swift/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec swift run -c release --skip-build build-your-own-{{course_slug}} "$@"
+exec swift run -c release --skip-build --build-path /tmp/codecrafters-build-{{course_slug}}-swift build-your-own-{{course_slug}} "$@"

--- a/languages/swift/code/.gitignore
+++ b/languages/swift/code/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+.build
+Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/languages/swift/code/Package.swift
+++ b/languages/swift/code/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "build-your-own-{{course_slug}}",
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "build-your-own-{{course_slug}}"),
+    ]
+)

--- a/languages/swift/code/Sources/main.swift
+++ b/languages/swift/code/Sources/main.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+// You can use print statements as follows for debugging, they'll be visible when running tests.
+print("Logs from your program will appear here!")
+
+// Uncomment this block to pass the first stage
+// print("Implement code to pass stage 1 here!")

--- a/languages/swift/config.yml
+++ b/languages/swift/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: "swift (>=6.0)"
+  user_editable_file: Sources/main.swift

--- a/languages/swift/dockerfiles/swift-6.0.Dockerfile
+++ b/languages/swift/dockerfiles/swift-6.0.Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM swift:6.0-focal
+
+# Ensures the container is re-built if Package.swift changes
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Package.swift"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app

--- a/languages/swift/dockerfiles/swift-6.0.Dockerfile
+++ b/languages/swift/dockerfiles/swift-6.0.Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 # .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
 COPY --exclude=.git --exclude=README.md . /app
 
-# Cache dependencies
+RUN .codecrafters/compile.sh
+
+# Cache dependencies (TODO: Check if this is required, or whether build implicitly caches dependencies)
 RUN swift package --build-path /tmp/codecrafters-build-{{course_slug}}-swift resolve
-RUN swift build -c release --build-path /tmp/codecrafters-build-{{course_slug}}-swift

--- a/languages/swift/dockerfiles/swift-6.0.Dockerfile
+++ b/languages/swift/dockerfiles/swift-6.0.Dockerfile
@@ -8,3 +8,7 @@ WORKDIR /app
 
 # .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
 COPY --exclude=.git --exclude=README.md . /app
+
+# Cache dependencies
+RUN swift package --build-path /tmp/codecrafters-build-{{course_slug}}-swift resolve
+RUN swift build -c release --build-path /tmp/codecrafters-build-{{course_slug}}-swift


### PR DESCRIPTION
Hello!

As I [mentioned in the forums](https://forum.codecrafters.io/t/how-to-move-a-supported-language-from-alpha-to-beta-for-general-availability/2044) earlier today, I'm a big fan CodeCrafters and Swift, so I wanted to help bring Swift to more of your challenges for folks to start using once enabled on the site.

This PR adds the template files to support Swift scripting. I've tested this locally with the [build-your-own-interpreter](https://github.com/codecrafters-io/build-your-own-interpreter) repo and it works great in my experience. I will link the relevant PR for that repo in a follow-up message.