### PR TITLE
Use correct course-slug reference for Clojure

### DIFF
--- a/languages/clojure/config.yml
+++ b/languages/clojure/config.yml
@@ -1,3 +1,3 @@
 attributes:
   required_executable: clj
-  user_editable_file: src/{{course_slug}}/core.clj
+  user_editable_file: src/{{course_slug_underscorized}}/core.clj


### PR DESCRIPTION
I` think @andy1li updated this in the original PR and I didn't know.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the configuration for the Clojure language environment to use a revised template variable for the user-editable file path. This may affect how course directories are referenced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->