### PR TITLE
Simplify script dir assignment in python/run.sh

### DIFF
--- a/languages/python/code/.codecrafters/run.sh
+++ b/languages/python/code/.codecrafters/run.sh
@@ -8,7 +8,7 @@
 
 set -e # Exit on failure
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(dirname "$0")"
 
 # This is done to exclude pwd from the python's path variable
 # This prevents accidentally launching a module if it s present inside pwd


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Shell script update**
> 
> - In `languages/python/code/.codecrafters/run.sh`, simplify `SCRIPT_DIR` assignment from `"$(cd "$(dirname "$0")" && pwd)"` to `"$(dirname "$0")"`.
> - `uv run` invocation remains the same, using `PYTHONPATH` and `--project` set to `SCRIPT_DIR`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07a0a5fc6f297a43976d91e5a2d788c26539663f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->