### PR TITLE
fix(zig): add curl and ca-certificates packages to zig-0.15.2 Dockerfile

### DIFF
--- a/languages/zig/dockerfiles/zig-0.15.2.Dockerfile
+++ b/languages/zig/dockerfiles/zig-0.15.2.Dockerfile
@@ -3,6 +3,8 @@ FROM debian:trixie
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
+        ca-certificates=20250419 \
+        curl=8.14.1-2+deb13u2 \
         libncurses-dev=6.5+20250216-2 \
         libreadline-dev=8.2-6 \
         xz-utils=5.8.1-1 && \


### PR DESCRIPTION
## Problem

The `zig-0.15.2.Dockerfile` fails during Docker build because `curl` and `ca-certificates` are not installed, but the RUN command on line 15 uses curl to download the Zig compiler over HTTPS.

### Error Output
```
#9 [3/8] RUN curl -O https://ziglang.org/download/0.15.2/...
#9 0.455 /bin/sh: 1: curl: not found
#9 ERROR: exit code: 127
```

After adding curl alone:
```
#9 0.321 curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt
```

## Root Cause

When the Dockerfile was updated from Alpine to Debian Trixie in commit [6288895](https://github.com/codecrafters-io/language-templates/commit/62888957afcba07c7bf9a4fa9e91f71deb793fb3), the `curl` and `ca-certificates` packages were inadvertently omitted. Alpine includes these by default, but Debian requires explicit installation.

## Solution

Add `curl` and `ca-certificates` to the apt-get install command with pinned versions:
- `ca-certificates=20250419` (latest for Debian Trixie)
- `curl=8.14.1-2+deb13u2` (matches other pinned package versions)

## Testing

Tested locally with a CodeCrafters shell challenge:
- **Before fix**: Build fails with "curl: not found"
- **After fix**: Build succeeds, Zig downloads and installs correctly, `zig version` returns `0.15.2`

## Impact

This fix enables all Zig 0.15.2 users to successfully build their CodeCrafters projects without manual Dockerfile modifications.

---

*Note: This issue was discovered while building a local testing tool for CodeCrafters challenges, with assistance from a coding agent during real-world Zig project testing.*