### PR TITLE
Update main.go to use FprintLn to `os.Stderr` instead of stdout

### DIFF
--- a/languages/go/code/app/main.go
+++ b/languages/go/code/app/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
 )
 
 func main() {
 	// You can use print statements as follows for debugging, they'll be visible when running tests.
-	fmt.Println("Logs from your program will appear here!")
+	fmt.Fprintln(os.Stderr, "Logs from your program will appear here!")
 
 	// TODO: Uncomment the code below to pass the first stage
 	// fmt.Println("Implement code here!")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change limited to where a single message is written (stdout vs stderr) with no business logic or data handling impact.
> 
> **Overview**
> Updates `main.go` to print the initial "Logs from your program will appear here!" message via `fmt.Fprintln(os.Stderr, ...)` rather than `fmt.Println(...)`, and adds the required `os` import so log output no longer pollutes stdout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c628e00a40e0eff3edf3820ea8d584131f9ba89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->