### PR TITLE
Add dart template

### DIFF
--- a/languages/dart/code/.codecrafters/compile.sh
+++ b/languages/dart/code/.codecrafters/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+dart pub get
+dart compile exe bin/main.dart -o /tmp/codecrafters-build-claude-code-dart

--- a/languages/dart/code/.codecrafters/compile.sh
+++ b/languages/dart/code/.codecrafters/compile.sh
@@ -9,4 +9,4 @@
 set -e # Exit on failure
 
 dart pub get
-dart compile exe bin/main.dart -o /tmp/codecrafters-build-claude-code-dart
+dart compile exe bin/main.dart -o /tmp/codecrafters-build-{{course_slug}}-dart

--- a/languages/dart/code/.codecrafters/run.sh
+++ b/languages/dart/code/.codecrafters/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+exec /tmp/codecrafters-build-claude-code-dart "$@"

--- a/languages/dart/code/.codecrafters/run.sh
+++ b/languages/dart/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec /tmp/codecrafters-build-claude-code-dart "$@"
+exec /tmp/codecrafters-build-{{course_slug}}-dart "$@"

--- a/languages/dart/code/.gitignore
+++ b/languages/dart/code/.gitignore
@@ -1,0 +1,5 @@
+# Dart/Flutter
+.dart_tool/
+.packages
+build/
+pubspec.lock

--- a/languages/dart/code/.gitignore
+++ b/languages/dart/code/.gitignore
@@ -2,4 +2,3 @@
 .dart_tool/
 .packages
 build/
-pubspec.lock

--- a/languages/dart/code/bin/main.dart
+++ b/languages/dart/code/bin/main.dart
@@ -1,0 +1,9 @@
+import 'dart:io';
+
+void main(List<String> arguments) {
+  // You can use print statements as follows for debugging, they'll be visible when running tests.
+  stderr.writeln('Logs from your program will appear here!');
+
+  // TODO: Uncomment the following line to pass the first stage
+  // print("Implement code here!");
+}

--- a/languages/dart/code/pubspec.yaml
+++ b/languages/dart/code/pubspec.yaml
@@ -1,0 +1,5 @@
+name: codecrafters-{{course_slug}}
+version: 0.1.0
+
+environment:
+  sdk: ^3.11.0

--- a/languages/dart/config.yml
+++ b/languages/dart/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: dart (3.11)
+  user_editable_file: bin/main.dart

--- a/languages/dart/dockerfiles/dart-3.11.Dockerfile
+++ b/languages/dart/dockerfiles/dart-3.11.Dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM dart:3.11.0
+
+# Ensures the container is re-built if dependency files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="pubspec.yaml,pubspec.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+RUN dart pub get


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds a new Dart language template and container/build scripts; changes are isolated to new files with minimal impact on existing languages.
> 
> **Overview**
> Adds a new **Dart (3.11)** language template, including a minimal `bin/main.dart` entrypoint and `pubspec.yaml` for dependency management.
> 
> Introduces CodeCrafters integration scripts (`.codecrafters/compile.sh` to `dart compile exe`, and `.codecrafters/run.sh` to execute the compiled binary), plus a Dart-specific `.gitignore`.
> 
> Adds a `dart-3.11` Dockerfile to provision the Dart SDK, copy template sources, and prefetch dependencies (`dart pub get`), and registers the template via `languages/dart/config.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 646287bef669eceeb41fa179654dfb496d0b17fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->